### PR TITLE
fix: infinite loop in escape.c

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+all_pgn.tcl
+cd2j1939
+cd2j1939.o
+escape
+escape.o
+j1939-flat.tsv
+j1939.txt
+j1939_decode.c
+j1939_decode.o
+j1939_msg.h
+j1939_print.c
+j1939_print.o
+j1939_slot.h

--- a/escape.c
+++ b/escape.c
@@ -7,7 +7,7 @@
 
 #define QUOTE 0x27
 
-static void put(char val, int inside)
+static void put(int val, int inside)
 {
 	if (inside) {
 		switch (val) {
@@ -30,14 +30,9 @@ static void put(char val, int inside)
 
 int main()
 {
-	int inside = 0, qcnt = 0;
-	char val;
+	int inside = 0, qcnt = 0, val;
 
-	while (1) {
-		val = getchar();
-		if (val == EOF) {
-			break;
-		}
+	while ((val = getchar()) && EOF != val) {
 		switch (qcnt) {
 		case 0:
 			if (val == QUOTE) {


### PR DESCRIPTION
fix: infinite loop in `escape.c` because getchar() return an int value.
add: `.gitignore` file